### PR TITLE
events. added new phone-island-call-actions-*

### DIFF
--- a/docs/EVENTS.md
+++ b/docs/EVENTS.md
@@ -259,6 +259,16 @@ eventDispatch(`<event-name>`, `<data-object>`)
     "deviceId": "2d331f699ec92b95000f3a656ab1d6ff9f17b3c9502c4a8db1d3f91905b5743f" // string - The output deviceId obtained by getUserMediaDevices
   }
   ```
+- `phone-island-call-actions-open` The event to open actions view
+
+  ```json
+  {}
+  ```
+- `phone-island-call-actions-close` The event to close actions view
+
+  ```json
+  {}
+  ```
 
 ## Dispatch Call Events - phone-island-call-*
 
@@ -377,6 +387,14 @@ eventDispatch(`<event-name>`, `<data-object>`)
   {}
 
 - `phone-island-call-audio-output-switched` The dispatch of call output switch
+
+  ```json
+  {}
+- `phone-island-call-actions-opened` The dispatch of call actions open
+
+  ```json
+  {}
+- `phone-island-call-actions-closed` The dispatch of call actions close
 
   ```json
   {}

--- a/src/components/CallView/Actions.tsx
+++ b/src/components/CallView/Actions.tsx
@@ -103,19 +103,19 @@ const Actions: FC = () => {
 
   useEventListener('phone-island-call-actions-open', () => {
     dispatch.island.toggleActionsExpanded(true)
-    eventDispatch('phone-island-actions-opened', {})
+    eventDispatch('phone-island-call-actions-opened', {})
   })
   useEventListener('phone-island-call-actions-close', () => {
     dispatch.island.toggleActionsExpanded(false)
-    eventDispatch('phone-island-actions-closed', {})
+    eventDispatch('phone-island-call-actions-closed', {})
   })
   function toggleActionsExpanded() {
     if (actionsExpanded) {
       dispatch.island.toggleActionsExpanded(false)
-      eventDispatch('phone-island-actions-closed', {})
+      eventDispatch('phone-island-call-actions-closed', {})
     } else {
       dispatch.island.toggleActionsExpanded(true)
-      eventDispatch('phone-island-actions-opened', {})
+      eventDispatch('phone-island-call-actions-opened', {})
     }
   }
 

--- a/src/components/CallView/Actions.tsx
+++ b/src/components/CallView/Actions.tsx
@@ -101,11 +101,21 @@ const Actions: FC = () => {
     }, 500)
   }
 
+  useEventListener('phone-island-call-actions-open', () => {
+    dispatch.island.toggleActionsExpanded(true)
+    eventDispatch('phone-island-actions-opened', {})
+  })
+  useEventListener('phone-island-call-actions-close', () => {
+    dispatch.island.toggleActionsExpanded(false)
+    eventDispatch('phone-island-actions-closed', {})
+  })
   function toggleActionsExpanded() {
     if (actionsExpanded) {
       dispatch.island.toggleActionsExpanded(false)
+      eventDispatch('phone-island-actions-closed', {})
     } else {
       dispatch.island.toggleActionsExpanded(true)
+      eventDispatch('phone-island-actions-opened', {})
     }
   }
 
@@ -169,9 +179,17 @@ const Actions: FC = () => {
           }
         >
           {actionsExpanded ? (
-            <FontAwesomeIcon className='pi-text-gray-700 dark:pi-text-gray-100' size='xl' icon={faChevronUp} />
+            <FontAwesomeIcon
+              className='pi-text-gray-700 dark:pi-text-gray-100'
+              size='xl'
+              icon={faChevronUp}
+            />
           ) : (
-            <FontAwesomeIcon size='xl' className='pi-text-gray-700 dark:pi-text-gray-100' icon={faChevronDown} />
+            <FontAwesomeIcon
+              size='xl'
+              className='pi-text-gray-700 dark:pi-text-gray-100'
+              icon={faChevronDown}
+            />
           )}
         </Button>
       </div>

--- a/src/components/Socket.tsx
+++ b/src/components/Socket.tsx
@@ -57,6 +57,7 @@ export const Socket: FC<SocketProps> = ({
       accepted: true,
       incoming: conv.direction === 'in' ? false : undefined,
     })
+    eventDispatch('phone-island-call-answered', {})
 
     // Stop the local audio element ringing
     store.dispatch.player.stopAudioPlayer()

--- a/src/lib/island/island.ts
+++ b/src/lib/island/island.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { store } from '../../store'
+import { eventDispatch } from '../../utils'
 
 /**
  * Retrieve the position on x axis
@@ -35,5 +36,8 @@ export function yPosition(y: number, islandElement: HTMLElement, containerElemen
  * Sets callview as the current view
  */
 export function backToCallView() {
+  eventDispatch('phone-island-call-keypad-closed', {})
+  eventDispatch('phone-island-call-transfer-closed', {})
+
   store.dispatch.island.setIslandView('call')
 }

--- a/src/lib/island/island.ts
+++ b/src/lib/island/island.ts
@@ -36,8 +36,8 @@ export function yPosition(y: number, islandElement: HTMLElement, containerElemen
  * Sets callview as the current view
  */
 export function backToCallView() {
-  eventDispatch('phone-island-call-keypad-closed', {})
-  eventDispatch('phone-island-call-transfer-closed', {})
+  const { view } = store.getState().island
+  eventDispatch(`phone-island-call-${view}-closed`, {})
 
   store.dispatch.island.setIslandView('call')
 }

--- a/src/lib/phone/call.ts
+++ b/src/lib/phone/call.ts
@@ -50,8 +50,6 @@ export function answerIncomingCall() {
   } else {
     answerPhysical()
   }
-
-  eventDispatch('phone-island-call-answered', {})
 }
 
 /**


### PR DESCRIPTION
New events:

Listen:
- `phone-island-call-actions-open`
- `phone-island-call-actions-close`

Dispatch:
- `phone-island-call-actions-opened`
- `phone-island-call-actions-closed`

Fixed events:
- `phone-island-call-keypad-closed`
- `phone-island-call-transfer-closed`
- `phone-island-call-answered`