### PR TITLE
fix: remove echo test ad audio output set

### DIFF
--- a/src/components/Socket.tsx
+++ b/src/components/Socket.tsx
@@ -510,7 +510,7 @@ export const Socket: FC<SocketProps> = ({
           (res.cause === 'normal_clearing' &&
             (extensionType === 'physical' || extensionType === 'mobile')) ||
           (res.cause === 'normal_clearing' &&
-            extensionType === 'webrtc' &&
+            (extensionType === 'webrtc' || extensionType === 'nethlink') &&
             previewCallFromMobileOrNethlink) ||
           res?.cause === 'user_busy' ||
           res?.cause === 'not_defined' ||

--- a/src/components/WebRTC.tsx
+++ b/src/components/WebRTC.tsx
@@ -13,7 +13,7 @@ import { checkMediaPermissions } from '../lib/devices/devices'
 import { attendedTransfer, hangupCurrentCall } from '../lib/phone/call'
 import { webrtcCheck } from '../lib/webrtc/connection'
 import outgoingRingtone from '../static/outgoing_ringtone'
-import { eventDispatch, useEventListener, getJSONItem } from '../utils'
+import { eventDispatch, useEventListener, getJSONItem, setJSONItem } from '../utils'
 import { isPhysical } from '../lib/user/default_device'
 
 interface WebRTCProps {
@@ -536,13 +536,48 @@ export const WebRTC: FC<WebRTCProps> = ({
                       const defaultAudioOutputDevice: any = getJSONItem('phone-island-audio-output-device')
 
                       if (defaultAudioOutputDevice?.deviceId) {
-                        remoteAudioElement.current.setSinkId(defaultAudioOutputDevice.deviceId)
-                          .then(() => {
-                            console.info('Audio output device applied successfully to new stream:', defaultAudioOutputDevice.deviceId)
-                          })
-                          .catch((err) => {
-                            console.warn('Failed to apply saved audio output device to new stream:', err)
-                          })
+                        const applySavedDevice = async () => {
+                          let targetDeviceId = defaultAudioOutputDevice.deviceId
+
+                          // Check if the saved device is still available
+                          if (targetDeviceId && targetDeviceId !== 'default') {
+                            try {
+                              const devices = await navigator.mediaDevices.enumerateDevices()
+                              const audioOutputDevices = devices.filter(device => device.kind === 'audiooutput')
+                              const deviceExists = audioOutputDevices.some(device => device.deviceId === targetDeviceId)
+
+                              if (!deviceExists) {
+                                console.warn(`Saved audio device ${targetDeviceId} no longer available, using default device`)
+                                targetDeviceId = 'default'
+                                // Update localStorage with the fallback
+                                setJSONItem('phone-island-audio-output-device', { deviceId: 'default' })
+                              }
+                            } catch (err) {
+                              console.warn('Error checking device availability, using default:', err)
+                              targetDeviceId = 'default'
+                            }
+                          }
+
+                          // Apply the device
+                          try {
+                            await remoteAudioElement.current.setSinkId(targetDeviceId)
+                            console.info('Audio output device applied successfully to new stream:', targetDeviceId)
+                          } catch (err) {
+                            console.warn('Failed to apply audio output device to new stream:', err)
+                            // Final fallback to default if not already using it
+                            if (targetDeviceId !== 'default') {
+                              try {
+                                await remoteAudioElement.current.setSinkId('default')
+                                setJSONItem('phone-island-audio-output-device', { deviceId: 'default' })
+                                console.info('Fallback to default device successful')
+                              } catch (defaultErr) {
+                                console.error('Even default device failed:', defaultErr)
+                              }
+                            }
+                          }
+                        }
+
+                        applySavedDevice()
                       }
                     }
                     // Save the new audio stream to the store

--- a/src/components/WebRTC.tsx
+++ b/src/components/WebRTC.tsx
@@ -13,7 +13,7 @@ import { checkMediaPermissions } from '../lib/devices/devices'
 import { attendedTransfer, hangupCurrentCall } from '../lib/phone/call'
 import { webrtcCheck } from '../lib/webrtc/connection'
 import outgoingRingtone from '../static/outgoing_ringtone'
-import { eventDispatch, useEventListener } from '../utils'
+import { eventDispatch, useEventListener, getJSONItem } from '../utils'
 import { isPhysical } from '../lib/user/default_device'
 
 interface WebRTCProps {
@@ -531,6 +531,19 @@ export const WebRTC: FC<WebRTCProps> = ({
                       janus.current.attachMediaStream
                     ) {
                       janus.current.attachMediaStream(remoteAudioElement.current, stream)
+
+                      // Apply saved audio output device if available
+                      const defaultAudioOutputDevice: any = getJSONItem('phone-island-audio-output-device')
+
+                      if (defaultAudioOutputDevice?.deviceId) {
+                        remoteAudioElement.current.setSinkId(defaultAudioOutputDevice.deviceId)
+                          .then(() => {
+                            console.info('Audio output device applied successfully to new stream:', defaultAudioOutputDevice.deviceId)
+                          })
+                          .catch((err) => {
+                            console.warn('Failed to apply saved audio output device to new stream:', err)
+                          })
+                      }
                     }
                     // Save the new audio stream to the store
                     store.dispatch.webrtc.updateRemoteAudioStream(stream)

--- a/src/lib/devices/devices.ts
+++ b/src/lib/devices/devices.ts
@@ -10,7 +10,7 @@ import JanusLib from '../webrtc/janus'
 import { JanusTypes } from '../../types'
 import { store } from '../../store'
 import { isPhysical } from '../user/default_device'
-import { getJSONItem } from '../../utils'
+import { getJSONItem, setJSONItem } from '../../utils'
 import { eventDispatch} from '../../utils/genericFunctions/eventDispatch'
 
 const Janus: JanusTypes = JanusLib
@@ -150,7 +150,17 @@ export const getCurrentVideoInputDeviceId = function () {
   if (deviceFound) {
     return currentDeviceId
   } else {
-    return null
+    // Fallback to default device
+    const defaultDevice = videoInputDevices.find(device => device.deviceId === 'default' || device.deviceId === '') || videoInputDevices[0]
+    const fallbackDeviceId = defaultDevice ? defaultDevice.deviceId : 'default'
+
+    if (currentDeviceId !== null && fallbackDeviceId !== currentDeviceId) {
+      console.warn(`Video input device ${currentDeviceId} no longer available, falling back to default device`)
+      // Update localStorage with the fallback device
+      setJSONItem('phone-island-video-input-device', { deviceId: fallbackDeviceId })
+    }
+
+    return fallbackDeviceId
   }
 }
 
@@ -164,7 +174,17 @@ export const getCurrentAudioInputDeviceId = function () {
   if (deviceFound) {
     return currentDeviceId
   } else {
-    return null
+    // Fallback to default device
+    const defaultDevice = audioInputDevices.find(device => device.deviceId === 'default' || device.deviceId === '') || audioInputDevices[0]
+    const fallbackDeviceId = defaultDevice ? defaultDevice.deviceId : 'default'
+
+    if (currentDeviceId !== null && fallbackDeviceId !== currentDeviceId) {
+      console.warn(`Audio input device ${currentDeviceId} no longer available, falling back to default device`)
+      // Update localStorage with the fallback device
+      setJSONItem('phone-island-audio-input-device', { deviceId: fallbackDeviceId })
+    }
+
+    return fallbackDeviceId
   }
 }
 
@@ -178,6 +198,16 @@ export const getCurrentAudioOutputDeviceId = function () {
   if (deviceFound) {
     return currentDeviceId
   } else {
-    return null
+    // Fallback to default device
+    const defaultDevice = audioOutputDevices.find(device => device.deviceId === 'default' || device.deviceId === '') || audioOutputDevices[0]
+    const fallbackDeviceId = defaultDevice ? defaultDevice.deviceId : 'default'
+
+    if (currentDeviceId !== null && fallbackDeviceId !== currentDeviceId) {
+      console.warn(`Audio output device ${currentDeviceId} no longer available, falling back to default device`)
+      // Update localStorage with the fallback device
+      setJSONItem('phone-island-audio-output-device', { deviceId: fallbackDeviceId })
+    }
+
+    return fallbackDeviceId
   }
 }


### PR DESCRIPTION
Removed Echo test as a method to set audio output device and usa a fake silent oscillator to simulate the MediaStream