### PR TITLE
fix(callview): avoid showing the external number twice when not in the phonebook

### DIFF
--- a/src/components/CallView/Number.tsx
+++ b/src/components/CallView/Number.tsx
@@ -8,9 +8,16 @@ import { StyledNumber } from '../../styles/Island.styles'
 import { useTranslation } from 'react-i18next'
 
 const Number: FC = () => {
-  const { number } = useSelector((state: RootState) => state.currentCall)
+  const { number, displayName } = useSelector((state: RootState) => state.currentCall)
   const { isOpen } = useSelector((state: RootState) => state.island)
   const { t } = useTranslation()
+
+  // When the counterpart is not in the phonebook, getDisplayName falls back to the
+  // number itself, so it is already shown as the display name. Rendering it here too
+  // would duplicate the number (display name + number), so skip it in that case.
+  if (number && displayName && number === displayName) {
+    return null
+  }
 
   const displayNumber =
     number === 'unknown' ? t('TextScroll.unknown') : number || t('Call.In progress...') || '-'


### PR DESCRIPTION
When receiving or placing a call from an external number **not in the phonebook**, the expanded call view (and the video-streaming view) showed the number **twice**: once as the display name and once as the number.

`getDisplayName` (`src/lib/phone/conversation.ts`) falls back to `counterpartNum` when `counterpartName` is `<unknown>`/empty, and the expanded view renders both `<DisplayName />` (= the number) and `<Number />` (= the same number).

## Change
`Number.tsx` now skips rendering when `number === displayName` (i.e. the display name is just the number fallback). When a real contact name is resolved, the number is still shown below it.

## Test Case
1. Call the phone-island from an external number NOT in the phonebook, expand the call view while ringing: the number appears only once.
2. Call from a contact in the phonebook: name as display name + number below it (unchanged).

Reference:
- NethServer/dev#8048