### PR TITLE
fix(connection): recover from stuck reload cycle and dead socket after network loss

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -143,8 +143,24 @@ const PhoneIslandComponent = forwardRef<PhoneIslandRef, PhoneIslandProps>(
       setReload(false)
       setReloadedWebRTC(false)
       setReloadedSocket(false)
+      store.dispatch.island.setForceReload(false)
     }
   }, [reloadedSocket, reloadedWebRTC])
+
+  // Failsafe: if a reload cycle never completes (a reload effect returning
+  // without calling its reloaded callback), reload would stay true forever,
+  // making both the automatic monitor and the manual refresh button no-ops
+  useEffect(() => {
+    if (!reload) return
+    const failsafe = setTimeout(() => {
+      console.warn('Reload cycle did not complete within 30s, resetting reload state')
+      setReload(false)
+      setReloadedWebRTC(false)
+      setReloadedSocket(false)
+      store.dispatch.island.setForceReload(false)
+    }, 30000)
+    return () => clearTimeout(failsafe)
+  }, [reload])
 
   // Monitor alerts and trigger automatic reload when webrtc_down or socket_down become active
   useEffect(() => {

--- a/src/components/Socket.tsx
+++ b/src/components/Socket.tsx
@@ -979,8 +979,10 @@ export const Socket: FC<SocketProps> = ({
 
                     if (isStaleConnection) {
                       console.warn('Stale socket connection detected - forcing reconnection')
-                      // Force disconnect to trigger reconnection
+                      // A manual disconnect() disables socket.io auto-reconnection,
+                      // so an explicit connect() is required to actually reconnect
                       socket.current.disconnect()
+                      socket.current.connect()
                     }
 
                     dispatch.alerts.setAlert('socket_down')
@@ -1560,20 +1562,22 @@ export const Socket: FC<SocketProps> = ({
       const { data } = store.getState().alerts
       const { forceReload } = store.getState().island
 
-      // Check if socket is actually down using alerts (more reliable than socket.connected)
+      // Check the alert but also the real socket state: the socket can be
+      // disconnected without the socket_down alert being active, because the
+      // ping interval is cleared on disconnect so no ping ever fails
       const isSocketDown = data.socket_down?.active || false
+      const isSocketDisconnected = !socket.current?.connected
 
-      // Only reconnect if socket_down alert is active OR force reload is requested
-      if (isSocketDown || forceReload) {
+      // Only reconnect if socket is down/disconnected OR force reload is requested
+      if (isSocketDown || isSocketDisconnected || forceReload) {
         console.info(
           forceReload
             ? 'Force reload requested, performing Socket reconnection'
-            : 'Socket down detected (alert active), performing reconnection',
+            : 'Socket down detected (alert active or disconnected), performing reconnection',
         )
-        // Reset force reload flag
-        if (forceReload) {
-          store.dispatch.island.setForceReload(false)
-        }
+        // Note: forceReload is NOT reset here, the WebRTC reload effect runs
+        // after this one and needs to read it too; App resets it when the
+        // reload cycle completes
         // Clear the connection check interval to avoid stale ping timeouts during reconnection
         if (connectionCheckInterval.current) {
           clearInterval(connectionCheckInterval.current)

--- a/src/components/WebRTC.tsx
+++ b/src/components/WebRTC.tsx
@@ -445,6 +445,20 @@ export const WebRTC: FC<WebRTCProps> = ({
                           janus.current.error(
                             'Registration failed: ' + result['code'] + ' ' + result['reason'],
                           )
+                        // Init is over (unsuccessfully): reset the init state now,
+                        // otherwise reload requests are skipped until the 30s safety
+                        // timeout and no registration retry is ever scheduled
+                        isInitializing.current = false
+                        if (initTimeoutRef.current) {
+                          clearTimeout(initTimeoutRef.current)
+                          initTimeoutRef.current = null
+                        }
+                        store.dispatch.webrtc.updateWebRTC({
+                          registered: false,
+                        })
+                        // Set the alert so the automatic reload monitor retries
+                        dispatch.alerts.setAlert('webrtc_down')
+                        eventDispatch('phone-island-alert-set', { type: 'webrtc_down' })
                         break
 
                       case 'unregistered':
@@ -1223,6 +1237,9 @@ export const WebRTC: FC<WebRTCProps> = ({
           })
         }
 
+        // If this run was also driven by a reload request, complete the cycle
+        // so App can reset the reload flag
+        if (reload && reloadedCallback) reloadedCallback()
         setConnectionReturned(false)
         return
       }
@@ -1234,6 +1251,10 @@ export const WebRTC: FC<WebRTCProps> = ({
             isReloading: isReloading.current,
             isInitializing: isInitializing.current
           })
+          // Complete the reload cycle anyway: without this callback the reload
+          // flag in App stays true forever and both the automatic monitor and
+          // the manual refresh button become no-ops
+          if (reloadedCallback) reloadedCallback()
           return
         }
 


### PR DESCRIPTION
## Problem

After a network loss (server restart, laptop standby, network blip) the client can end up permanently stuck in the **"Connection error"** state: no calls can be made or received, and the refresh button in the alert does nothing. Only a full page reload recovers.

Root cause, as observed in production logs and browser console:

1. When the connection drops, the automatic reload monitor triggers a reload cycle every 10s. If a cycle hits the `[JANUS-GUARD]` guard while a previous init is still in progress (`isInitializing` can stay `true` for up to 30s, or forever on `registration_failed`), the WebRTC reload effect returns **without calling `reloadedCallback()`**.
2. The `reload` flag in `App` is only reset when both Socket and WebRTC callbacks fire, so it stays latched to `true` forever. From that point the automatic monitor (which requires `!reload`) never fires again, and the refresh button (`setReload(true)` on an already-`true` state) is a React no-op — clicking it produces nothing.
3. Contributing issues: a SIP `registration_failed` (e.g. 503) was only logged, never retried; the stale-connection handler called `socket.disconnect()` which disables socket.io auto-reconnection without ever calling `connect()`; the Socket reload guard trusted the `socket_down` alert instead of the real socket state; and `forceReload` was consumed by the Socket effect before the WebRTC effect could read it.

## Fix

- **App**: reset the reload latch with a 30s failsafe if a cycle never completes; reset `forceReload` centrally when the cycle completes
- **WebRTC**: call `reloadedCallback()` also when a reload is skipped (guard and `connectionReturned` branches); on `registration_failed` reset `isInitializing`, mark as unregistered and set `webrtc_down` so registration is retried
- **Socket**: explicit `connect()` after the forced `disconnect()` on stale connections; reconnect also when the socket is actually disconnected even if the `socket_down` alert is not active; do not consume `forceReload` before WebRTC reads it

## How to reproduce

With a CTI client open (webrtc device), restart the backend services on the NS8 node:

```
runagent -m nethvoice1
systemctl --user restart janus nethcti-server
```

Without this fix the client can remain stuck on "Connection error" (refresh button dead, no console activity on click). With the fix it must always recover on its own within ~40s, and clicking the refresh icon must always produce a visible reload cycle in the console.